### PR TITLE
feat: auto resize chat textarea

### DIFF
--- a/components/Base/Textarea/BaseTextarea.vue
+++ b/components/Base/Textarea/BaseTextarea.vue
@@ -38,10 +38,11 @@ const model = defineModel<string>('modelValue')
   width: 100%;
   max-height: 500px;
   overflow: hidden;
-  padding: 0 $indent-l;
+  padding: 0;
   resize: none;
-  background: $color-base-medium;
-  color: $color-white;
+  border: 0;
+  background: transparent;
+  color: inherit;
   transition:
     border-color 0.2s ease-in-out,
     color 0.2s ease-in-out;

--- a/components/ui/ChatTextarea.vue
+++ b/components/ui/ChatTextarea.vue
@@ -21,53 +21,49 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, ref, watch } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
+
+interface Props {
+  maxRows?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  maxRows: 5,
+})
 
 const baseTextareaRef = ref<ComponentPublicInstance | null>(null)
 const message = ref('')
 
-const maxRows = 5
 const lineHeight = ref<number>(0)
 
 const getTextareaElement = () => {
-  const component = baseTextareaRef.value
-  if (!component) {
-    return null
-  }
-
-  return component.$el?.querySelector('textarea') ?? null
+  const element = baseTextareaRef.value?.$el?.querySelector('textarea')
+  return (element as HTMLTextAreaElement | null) ?? null
 }
 
 const ensureLineHeight = (textarea: HTMLTextAreaElement) => {
-  if (lineHeight.value) {
-    return
-  }
+  if (lineHeight.value) return
 
   const styles = window.getComputedStyle(textarea)
   const parsedLineHeight = parseFloat(styles.lineHeight)
 
-  if (Number.isFinite(parsedLineHeight)) {
-    lineHeight.value = parsedLineHeight
-    return
-  }
-
-  const fontSize = parseFloat(styles.fontSize)
-  lineHeight.value = Number.isFinite(fontSize) ? fontSize * 1.2 : 20
+  lineHeight.value =
+    Number.isFinite(parsedLineHeight) && parsedLineHeight > 0
+      ? parsedLineHeight
+      : 20
 }
 
 const resizeTextarea = () => {
   const textarea = getTextareaElement()
 
-  if (!textarea) {
-    return
-  }
+  if (!textarea) return
 
   ensureLineHeight(textarea)
 
   textarea.style.height = 'auto'
 
-  const maxHeight = lineHeight.value * maxRows
+  const rowsLimit = Math.max(props.maxRows, 1)
+  const maxHeight = lineHeight.value * rowsLimit
   const scrollHeight = textarea.scrollHeight
   const nextHeight = Math.min(scrollHeight, maxHeight)
 
@@ -76,13 +72,18 @@ const resizeTextarea = () => {
   textarea.style.maxHeight = `${maxHeight}px`
 }
 
-watch(message, async () => {
-  await nextTick()
+watch(message, () => {
   resizeTextarea()
 })
 
-onMounted(async () => {
-  await nextTick()
+watch(
+  () => props.maxRows,
+  () => {
+    resizeTextarea()
+  },
+)
+
+onMounted(() => {
   const textarea = getTextareaElement()
 
   if (textarea) {
@@ -104,13 +105,6 @@ onMounted(async () => {
 
   &__field {
     flex: 1;
-
-    :deep(textarea) {
-      width: 100%;
-      padding: 0;
-      border: 0;
-      background: transparent;
-    }
   }
 
   svg {

--- a/components/ui/ChatTextarea.vue
+++ b/components/ui/ChatTextarea.vue
@@ -1,14 +1,18 @@
 <template>
   <div class="chat-textarea">
-    <button>
+    <button type="button">
       <svg class="icon-30">
         <use :href="'/images/svg/icon-clip.svg#icon'" />
       </svg>
     </button>
 
-    <BaseTextarea class="chat-textarea__field" />
+    <BaseTextarea
+      ref="baseTextareaRef"
+      v-model="message"
+      class="chat-textarea__field"
+    />
 
-    <button>
+    <button type="button">
       <svg class="icon-30">
         <use :href="'/images/svg/icon-plane.svg#icon'" />
       </svg>
@@ -16,20 +20,97 @@
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { nextTick, onMounted, ref, watch } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
+
+const baseTextareaRef = ref<ComponentPublicInstance | null>(null)
+const message = ref('')
+
+const maxRows = 5
+const lineHeight = ref<number>(0)
+
+const getTextareaElement = () => {
+  const component = baseTextareaRef.value
+  if (!component) {
+    return null
+  }
+
+  return component.$el?.querySelector('textarea') ?? null
+}
+
+const ensureLineHeight = (textarea: HTMLTextAreaElement) => {
+  if (lineHeight.value) {
+    return
+  }
+
+  const styles = window.getComputedStyle(textarea)
+  const parsedLineHeight = parseFloat(styles.lineHeight)
+
+  if (Number.isFinite(parsedLineHeight)) {
+    lineHeight.value = parsedLineHeight
+    return
+  }
+
+  const fontSize = parseFloat(styles.fontSize)
+  lineHeight.value = Number.isFinite(fontSize) ? fontSize * 1.2 : 20
+}
+
+const resizeTextarea = () => {
+  const textarea = getTextareaElement()
+
+  if (!textarea) {
+    return
+  }
+
+  ensureLineHeight(textarea)
+
+  textarea.style.height = 'auto'
+
+  const maxHeight = lineHeight.value * maxRows
+  const scrollHeight = textarea.scrollHeight
+  const nextHeight = Math.min(scrollHeight, maxHeight)
+
+  textarea.style.height = `${nextHeight}px`
+  textarea.style.overflowY = scrollHeight > maxHeight ? 'auto' : 'hidden'
+  textarea.style.maxHeight = `${maxHeight}px`
+}
+
+watch(message, async () => {
+  await nextTick()
+  resizeTextarea()
+})
+
+onMounted(async () => {
+  await nextTick()
+  const textarea = getTextareaElement()
+
+  if (textarea) {
+    ensureLineHeight(textarea)
+    textarea.style.minHeight = `${lineHeight.value}px`
+  }
+
+  resizeTextarea()
+})
+</script>
 
 <style scoped lang="scss">
 .chat-textarea {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: $indent-s;
   padding: $indent-s $indent-l;
   background: $color-base-medium;
 
   &__field {
-    display: flex;
-    align-items: center;
-    width: 100%;
+    flex: 1;
+
+    :deep(textarea) {
+      width: 100%;
+      padding: 0;
+      border: 0;
+      background: transparent;
+    }
   }
 
   svg {


### PR DESCRIPTION
## Summary
- add local state to ChatTextarea and resize logic that grows up to five rows
- align styling so the textarea expands upward while keeping the action buttons fixed

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68dd58453a88832bb543b02b62833344